### PR TITLE
bugfix for neon config setup

### DIFF
--- a/src/DI/MailExtension.php
+++ b/src/DI/MailExtension.php
@@ -31,7 +31,7 @@ class MailExtension extends CompilerExtension
 	{
 		return Expect::structure([
 			'mode' => Expect::anyOf(...self::MODES)->default(self::MODE_STANDALONE),
-			'mailer' => Expect::type('string|' . Statement::class)->dynamic()->required(),
+			'mailer' => Expect::type('array|string|' . Statement::class)->dynamic()->required(),
 			'debug' => Expect::bool(false),
 		]);
 	}


### PR DESCRIPTION
nefungoval tento zapis v config.neon:
`post:`
`    mailer:`
`        class: Contributte\Mail\Mailer\SendmailMailer`
`        setup:`
`            - setBounceMail(%app.email%)`

