### PR TITLE
nette/mail 3.1 and stuff

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -145,6 +145,28 @@ Internally wraps your mailer and displays sent mails when the `debug` option is 
 
 ## Message
 
+### MessageFactory
+
+DIC-generated `Message` factory
+
+```php
+use Contributte\Mail\Message\IMessageFactory;
+
+class Foo
+{
+	
+    /** @var IMessageFactory @inject */
+    public $messageFactory;
+
+    public function sendMail(): void 
+    {
+        $message = $this->messageFactory->create();
+        // ...
+    }
+	
+}
+```
+
 ### `Message::addTos(array $tos)`
 
 This wrapper accepts an array of recipients and calls `addTo` on each one of them.

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Extra contribution to [`nette/mail`](https://github.com/nette/mail).
 
 | State       | Version | Branch   | Nette | PHP     |
 |-------------|---------|----------|-------|---------|
-| dev         | `^0.5`  | `master` | 3.0+  | `^7.2`  |
-| stable      | `^0.4`  | `master` | 3.0+  | `^7.2`  |
+| dev         | `^0.6`  | `master` | 3.0+  | `^7.2`  |
+| stable      | `^0.5`  | `master` | 3.0+  | `^7.2`  |
 | stable      | `^0.3`  | `master` | 2.4   | `>=7.1` |
 
 ## Maintainers

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require": {
     "php": "^7.2",
-    "nette/mail": "~3.0.0",
+    "nette/mail": "~3.1.0",
     "nette/utils": "~3.0.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "nette/utils": "~3.0.0"
   },
   "require-dev": {
-    "nette/di": "~3.0.0",
+    "contributte/di": "^0.4.0",
     "ninjify/nunjuck": "^0.2.0",
     "ninjify/qa": "^0.9.0",
     "phpstan/extension-installer": "^1.0",
@@ -31,11 +31,8 @@
     "phpstan/phpstan-strict-rules": "^0.11",
     "tracy/tracy": "~2.6.2"
   },
-  "conflict": {
-    "nette/di": "<=3.0.0-RC"
-  },
   "suggest": {
-    "nette/di": "to use MailerExtension[CompilerExtension]"
+    "contributte/di": "to use MailerExtension[CompilerExtension]"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.5.x-dev"
+      "dev-master": "0.6.x-dev"
     }
   }
 }

--- a/src/Mailer/CompositeMailer.php
+++ b/src/Mailer/CompositeMailer.php
@@ -2,15 +2,14 @@
 
 namespace Contributte\Mail\Mailer;
 
-use Exception;
-use Nette\Mail\IMailer;
+use Nette\Mail\Mailer;
 use Nette\Mail\Message;
 use Throwable;
 
-final class CompositeMailer implements IMailer
+final class CompositeMailer implements Mailer
 {
 
-	/** @var IMailer[] */
+	/** @var Mailer[] */
 	private $mailers = [];
 
 	/** @var bool */
@@ -21,7 +20,7 @@ final class CompositeMailer implements IMailer
 		$this->silent = $silent;
 	}
 
-	public function add(IMailer $mailer): void
+	public function add(Mailer $mailer): void
 	{
 		$this->mailers[] = $mailer;
 	}

--- a/src/Mailer/DevNullMailer.php
+++ b/src/Mailer/DevNullMailer.php
@@ -2,10 +2,10 @@
 
 namespace Contributte\Mail\Mailer;
 
-use Nette\Mail\IMailer;
+use Nette\Mail\Mailer;
 use Nette\Mail\Message;
 
-final class DevNullMailer implements IMailer
+final class DevNullMailer implements Mailer
 {
 
 	public function send(Message $mail): void

--- a/src/Mailer/DevOpsMailer.php
+++ b/src/Mailer/DevOpsMailer.php
@@ -2,19 +2,19 @@
 
 namespace Contributte\Mail\Mailer;
 
-use Nette\Mail\IMailer;
+use Nette\Mail\Mailer;
 use Nette\Mail\Message;
 
-final class DevOpsMailer implements IMailer
+final class DevOpsMailer implements Mailer
 {
 
-	/** @var IMailer */
+	/** @var Mailer */
 	private $mailer;
 
 	/** @var string */
 	private $mail;
 
-	public function __construct(IMailer $mailer, string $mail)
+	public function __construct(Mailer $mailer, string $mail)
 	{
 		$this->mailer = $mailer;
 		$this->mail = $mail;

--- a/src/Mailer/FileMailer.php
+++ b/src/Mailer/FileMailer.php
@@ -3,10 +3,10 @@
 namespace Contributte\Mail\Mailer;
 
 use Contributte\Mail\Exception\RuntimeException;
-use Nette\Mail\IMailer;
+use Nette\Mail\Mailer;
 use Nette\Mail\Message;
 
-final class FileMailer implements IMailer
+final class FileMailer implements Mailer
 {
 
 	/** @var string */

--- a/src/Mailer/TraceableMailer.php
+++ b/src/Mailer/TraceableMailer.php
@@ -2,19 +2,19 @@
 
 namespace Contributte\Mail\Mailer;
 
-use Nette\Mail\IMailer;
+use Nette\Mail\Mailer;
 use Nette\Mail\Message;
 
-final class TraceableMailer implements IMailer
+final class TraceableMailer implements Mailer
 {
 
-	/** @var IMailer */
+	/** @var Mailer */
 	private $mailer;
 
 	/** @var Message[] */
 	private $mails = [];
 
-	public function __construct(IMailer $mailer)
+	public function __construct(Mailer $mailer)
 	{
 		$this->mailer = $mailer;
 	}


### PR DESCRIPTION
- nette/mail 3.1
- MessageFactory docs
- Allow `@service` and array for `mailer` extension key
- Extension require contributte/di
- Removed `mailer->dynamic()` as it is useful only for dynamic container parameters